### PR TITLE
fixed nextauth url to use dynamic alb dns name

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -117,7 +117,6 @@ jobs:
           course_service_memory  = 512
           
           nextauth_secret      = "${{ secrets.NEXTAUTH_SECRET }}"
-          nextauth_url         = "${{ secrets.NEXTAUTH_URL }}"
           google_client_id     = "${{ secrets.GOOGLE_CLIENT_ID }}"
           google_client_secret = "${{ secrets.GOOGLE_CLIENT_SECRET }}"
           jwt_secret           = "${{ secrets.JWT_SECRET }}"
@@ -234,7 +233,6 @@ jobs:
           course_service_memory  = 512
           
           nextauth_secret      = "${{ secrets.NEXTAUTH_SECRET }}"
-          nextauth_url         = "${{ secrets.NEXTAUTH_URL }}"
           google_client_id     = "${{ secrets.GOOGLE_CLIENT_ID }}"
           google_client_secret = "${{ secrets.GOOGLE_CLIENT_SECRET }}"
           jwt_secret           = "${{ secrets.JWT_SECRET }}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,7 +75,6 @@ module "ecs" {
 
   # Environment variables
   nextauth_secret      = var.nextauth_secret
-  nextauth_url         = var.nextauth_url
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret
   jwt_secret           = var.jwt_secret

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -323,7 +323,7 @@ resource "aws_ecs_task_definition" "frontend" {
     }]
 
     environment = [
-      { name = "NEXTAUTH_URL", value = var.nextauth_url },
+      { name = "NEXTAUTH_URL", value = "http://${aws_lb.main.dns_name}" },
       { name = "NEXT_PUBLIC_BACKEND_URL", value = "http://${aws_lb.main.dns_name}" },
       { name = "INTERNAL_BACKEND_URL", value = "http://user-service.${aws_service_discovery_private_dns_namespace.main.name}:5000" },
       { name = "NEXT_PUBLIC_COURSE_SERVICE_URL", value = "http://${aws_lb.main.dns_name}" },

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -370,7 +370,7 @@ resource "aws_ecs_task_definition" "user_service" {
     environment = [
       { name = "PORT", value = "5000" },
       { name = "NODE_ENV", value = "production" },
-      { name = "FRONTEND_URL", value = var.nextauth_url },
+      { name = "FRONTEND_URL", value = "http://${aws_lb.main.dns_name}" },
       { name = "DATABASE_URL", value = var.database_url },
       { name = "JWT_SECRET", value = var.jwt_secret },
       { name = "JWT_REFRESH_SECRET", value = var.jwt_refresh_secret },
@@ -415,7 +415,7 @@ resource "aws_ecs_task_definition" "course_service" {
     environment = [
       { name = "PORT", value = "5001" },
       { name = "NODE_ENV", value = "production" },
-      { name = "FRONTEND_URL", value = var.nextauth_url },
+      { name = "FRONTEND_URL", value = "http://${aws_lb.main.dns_name}" },
       { name = "DATABASE_URL", value = var.database_url },
       { name = "JWT_SECRET", value = var.jwt_secret },
       { name = "JWT_REFRESH_SECRET", value = var.jwt_refresh_secret }

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -82,11 +82,6 @@ variable "nextauth_secret" {
   sensitive   = true
 }
 
-variable "nextauth_url" {
-  description = "NextAuth URL"
-  type        = string
-}
-
 variable "google_client_id" {
   description = "Google OAuth client ID"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -112,11 +112,6 @@ variable "nextauth_secret" {
   sensitive   = true
 }
 
-variable "nextauth_url" {
-  description = "NextAuth URL"
-  type        = string
-}
-
 variable "google_client_id" {
   description = "Google OAuth client ID"
   type        = string


### PR DESCRIPTION
## 🔧 Fix NextAuth URL Redirect Issue

This PR fixes the authentication redirect issue where clicking 'Login with Google' redirected to a wrong (old) ALB URL.

### 🐛 Problem
- **Current URL**: `http://academiasync-prod-alb-751525840.us-east-1.elb.amazonaws.com/`
- **Redirect URL**: `http://academiasync-prod-alb-662980377.us-east-1.elb.amazonaws.com/` (old, non-existent)
- Users got "This site can't be reached" error

### 🔍 Root Cause
- `NEXTAUTH_URL` was hardcoded in GitHub Secrets
- When ALB was destroyed/recreated, the DNS name changed
- Frontend container still used the old URL from secrets
- OAuth redirect went to non-existent ALB

### ✅ Solution
Changed `NEXTAUTH_URL` from **static secret** to **dynamic value**:

**Before:**
```hcl
environment = [
  { name = "NEXTAUTH_URL", value = var.nextauth_url },  # From secret
  ...
]
```

**After:**
```hcl
environment = [
  { name = "NEXTAUTH_URL", value = "http://${aws_lb.main.dns_name}" },  # Dynamic!
  ...
]
```

### 📦 Changes Made
- ✅ Updated `terraform/modules/ecs/main.tf` - Use dynamic ALB DNS
- ✅ Removed `nextauth_url` variable from all terraform files
- ✅ Removed `nextauth_url` from workflow tfvars
- ✅ Removed `NEXTAUTH_URL` secret dependency

### 🎯 Benefits
- ✅ **No more hardcoded URLs** - Always uses current ALB
- ✅ **Survives ALB recreation** - DNS automatically updated
- ✅ **One less secret to manage** - Simpler configuration
- ✅ **No manual updates needed** - Fully automated

### 🧪 Testing
After merge:
1. New task definition will be created with dynamic URL
2. ECS will redeploy frontend with correct `NEXTAUTH_URL`
3. Login redirect will work to current ALB
4. OAuth flow will complete successfully

---

**Impact:** Fixes authentication completely, no code changes needed