### PR TITLE
Force ECS services to use updated task definitions with dynamic NextAuth URL

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -460,7 +460,7 @@ resource "aws_ecs_service" "frontend" {
   depends_on = [aws_lb_listener.frontend]
 
   lifecycle {
-    ignore_changes = [task_definition, desired_count]
+    ignore_changes = [desired_count]
   }
 
   tags = {
@@ -495,7 +495,7 @@ resource "aws_ecs_service" "user_service" {
   depends_on = [aws_lb_listener.frontend]
 
   lifecycle {
-    ignore_changes = [task_definition, desired_count, load_balancer]
+    ignore_changes = [desired_count, load_balancer]
   }
 
   tags = {
@@ -530,7 +530,7 @@ resource "aws_ecs_service" "course_service" {
   depends_on = [aws_lb_listener.frontend]
 
   lifecycle {
-    ignore_changes = [task_definition, desired_count, load_balancer]
+    ignore_changes = [desired_count, load_balancer]
   }
 
   tags = {


### PR DESCRIPTION
## Problem
The ECS services are still using old task definitions with hardcoded NEXTAUTH_URL from GitHub Secrets. Even though PR #32 changed the task definition configuration to use dynamic ALB DNS, the services weren't updated because of `ignore_changes = [task_definition]` in the lifecycle block.

## Solution
Temporarily remove `task_definition` from the `ignore_changes` list to allow Terraform to update the ECS services with the new task definitions that have:
- `NEXTAUTH_URL = http://${aws_lb.main.dns_name}`
- `FRONTEND_URL = http://${aws_lb.main.dns_name}` (for backend services)

## Changes
- Removed `task_definition` from `lifecycle.ignore_changes` in all three ECS services (frontend, user-service, course-service)
- This will trigger a service update with new task definitions containing correct dynamic URLs

## After Merge
Once this is deployed and services are updated, we should add `task_definition` back to `ignore_changes` in a follow-up PR to prevent accidental updates in the future.