### PR TITLE
Restore task_definition to ignore_changes for ECS services

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -460,7 +460,7 @@ resource "aws_ecs_service" "frontend" {
   depends_on = [aws_lb_listener.frontend]
 
   lifecycle {
-    ignore_changes = [desired_count]
+    ignore_changes = [task_definition, desired_count]
   }
 
   tags = {
@@ -495,7 +495,7 @@ resource "aws_ecs_service" "user_service" {
   depends_on = [aws_lb_listener.frontend]
 
   lifecycle {
-    ignore_changes = [desired_count, load_balancer]
+    ignore_changes = [task_definition, desired_count, load_balancer]
   }
 
   tags = {
@@ -530,7 +530,7 @@ resource "aws_ecs_service" "course_service" {
   depends_on = [aws_lb_listener.frontend]
 
   lifecycle {
-    ignore_changes = [desired_count, load_balancer]
+    ignore_changes = [task_definition, desired_count, load_balancer]
   }
 
   tags = {


### PR DESCRIPTION
## Purpose
Restore the `task_definition` field to `ignore_changes` in the ECS service lifecycle blocks to prevent accidental service updates in future deployments.

## Context
- PR #33 temporarily removed `task_definition` from `ignore_changes` to force services to update with new task definitions containing dynamic NEXTAUTH_URL
- The service update was successfully applied - all three services (frontend, user-service, course-service) now use task definitions with:
  - `NEXTAUTH_URL = http://${aws_lb.main.dns_name}`
  - `FRONTEND_URL = http://${aws_lb.main.dns_name}`
- Now we restore the `ignore_changes` configuration to prevent Terraform from updating services unnecessarily on every apply

## Changes
- Added `task_definition` back to `lifecycle.ignore_changes` for:
  - `aws_ecs_service.frontend`
  - `aws_ecs_service.user_service`  
  - `aws_ecs_service.course_service`

## Result
- ECS services will not be updated automatically when task definitions change
- Manual service updates can still be triggered via AWS CLI when needed
- Prevents unnecessary service restarts during routine Terraform applies