### PR TITLE
Add detailed logging to NextAuth for OAuth debugging

### DIFF
--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -50,6 +50,8 @@ export const authOptions: AuthOptions = {
         async signIn({ account, profile }: { account: Account | null; profile?: Profile }) {
             if (account?.provider === "google" && account.id_token) {
                 try {
+                    console.log(`[NextAuth] Attempting to authenticate with backend: ${BACKEND_URL}/auth/google`);
+                    
                     // Send Google ID token to backend
                     const response = await fetch(`${BACKEND_URL}/auth/google`, {
                         method: "POST",
@@ -62,8 +64,11 @@ export const authOptions: AuthOptions = {
                         credentials: "include",
                     });
 
+                    console.log(`[NextAuth] Backend response status: ${response.status} ${response.statusText}`);
+
                     if (response.ok) {
                         const data = await response.json();
+                        console.log(`[NextAuth] Authentication successful for user:`, data.user?.email);
 
                         // Extract access token from Set-Cookie header
                         const setCookieHeader = response.headers.get('set-cookie');
@@ -96,11 +101,16 @@ export const authOptions: AuthOptions = {
                     //     return false;
                     // } 
                     else {
-                        console.error("Backend authentication failed:", await response.text());
+                        const errorText = await response.text();
+                        console.error(`[NextAuth] Backend authentication failed with status ${response.status}:`, errorText);
+                        console.error(`[NextAuth] Please check backend logs at: /ecs/academiasync-prod/user-service`);
                     }
                 } catch (error) {
-                    console.error("Error authenticating with backend:", error);
+                    console.error("[NextAuth] Error authenticating with backend:", error);
+                    console.error(`[NextAuth] Backend URL: ${BACKEND_URL}/auth/google`);
+                    console.error("[NextAuth] This could be a network connectivity issue");
                 }
+                console.error("[NextAuth] SignIn callback returning false - user will be redirected to login page");
                 return false;
             }
             return true;


### PR DESCRIPTION
## Purpose
Add comprehensive logging to the NextAuth signIn callback to help diagnose OAuth authentication issues.

## Problem
Users experiencing redirect loop after clicking "Continue with Google". The callback is returning false but we don't have enough information to diagnose why.

## Changes
Added detailed console.log statements to track:
1. Backend URL being called
2. Response status and status text
3. Success/failure messages with user email
4. Detailed error messages with HTTP status codes
5. Network connectivity error messages
6. Final callback return value

## Usage
After this is deployed, check the **frontend container logs** when attempting to sign in:

```bash
# View frontend logs
aws logs tail /ecs/academiasync-prod/frontend --follow --since 5m --format short

# Look for logs starting with [NextAuth]
```

## Expected Log Output

**Successful authentication:**
```
[NextAuth] Attempting to authenticate with backend: http://user-service.academiasync-prod.local:5000/auth/google
[NextAuth] Backend response status: 200 OK
[NextAuth] Authentication successful for user: user@example.com
```

**Failed authentication:**
```
[NextAuth] Attempting to authenticate with backend: http://user-service.academiasync-prod.local:5000/auth/google
[NextAuth] Backend response status: 401 Unauthorized
[NextAuth] Backend authentication failed with status 401: {"error":"Invalid Google token"}
[NextAuth] Please check backend logs at: /ecs/academiasync-prod/user-service
[NextAuth] SignIn callback returning false - user will be redirected to login page
```

**Network error:**
```
[NextAuth] Attempting to authenticate with backend: http://user-service.academiasync-prod.local:5000/auth/google
[NextAuth] Error authenticating with backend: TypeError: fetch failed
[NextAuth] Backend URL: http://user-service.academiasync-prod.local:5000/auth/google
[NextAuth] This could be a network connectivity issue
[NextAuth] SignIn callback returning false - user will be redirected to login page
```